### PR TITLE
Update syrupy.py to prevent unicode error

### DIFF
--- a/scripts/syrupy.py
+++ b/scripts/syrupy.py
@@ -161,6 +161,7 @@ def poll_process(pid=None,
         stdout=subprocess.PIPE)
     poll_time = datetime.datetime.now()
     stdout, stderr = communicate(ps)
+    stdout = stdout.encode('utf-8').strip()
 
     if debug_level >= 9:
         sys.stderr.write(stdout + "\n")


### PR DESCRIPTION
Hi,

After deploying Syrupy on the cloud environment,  sometimes Syrupy gives an error says 

"UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position xxxx"

before monitoring begins. Adding this line would solve the issue.

Thanks,
Roger